### PR TITLE
add optional setup/1 callback

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule RemotePersistentTerm.MixProject do
   use Mix.Project
 
   @name "RemotePersistentTerm"
-  @version "0.8.1"
+  @version "0.9.0"
   @repo_url "https://github.com/AppMonet/remote_persistent_term"
 
   def project do


### PR DESCRIPTION
I wanted to add an `:ets` storage option so we could store large terms that update frequently, but the default `get/0` api would not really be compatible with `:ets` as it would require copying the entire table in to the calling process.

Instead I am adding this `setup/1` callback, where you can start your ets table and then override `put/1` and define a custom `get/1` 