### PR TITLE
Fix how we get latest in s3 buckets

### DIFF
--- a/lib/remote_persistent_term/fetcher/s3.ex
+++ b/lib/remote_persistent_term/fetcher/s3.ex
@@ -45,6 +45,7 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
   """
   @impl true
   def init(opts) do
+    IO.inspect(Application.get_all_env(:ex_aws), label: "ExAws Config")
     with {:ok, valid_opts} <- NimbleOptions.validate(opts, @opts_schema) do
       {:ok,
        %__MODULE__{
@@ -113,7 +114,7 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
       %{is_latest: "true"} ->
         true
 
-      %{is_latest: "false"} ->
+      _ ->
         false
     end)
     |> case do

--- a/lib/remote_persistent_term/fetcher/s3.ex
+++ b/lib/remote_persistent_term/fetcher/s3.ex
@@ -45,7 +45,6 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
   """
   @impl true
   def init(opts) do
-    IO.inspect(Application.get_all_env(:ex_aws), label: "ExAws Config")
     with {:ok, valid_opts} <- NimbleOptions.validate(opts, @opts_schema) do
       {:ok,
        %__MODULE__{

--- a/lib/remote_persistent_term/fetcher/s3.ex
+++ b/lib/remote_persistent_term/fetcher/s3.ex
@@ -108,7 +108,6 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
   end
 
   defp find_latest([_ | _] = contents) do
-    dbg contents
     Enum.find(contents, fn
       %{is_latest: "true"} ->
         true

--- a/lib/remote_persistent_term/fetcher/s3.ex
+++ b/lib/remote_persistent_term/fetcher/s3.ex
@@ -57,9 +57,12 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
 
   @impl true
   def current_version(state) do
-    with {:ok, %{body: %{contents: contents}}} <- list_objects(state),
-         {:ok, %{e_tag: etag}} <- find_latest(contents, state.key) do
-      Logger.info("found latest version of s3://#{state.bucket}/#{state.key}: #{etag}")
+    with {:ok, versions} <- list_object_versions(state),
+         {:ok, %{etag: etag, version_id: version}} <- find_latest(versions) do
+      Logger.info(
+        "found latest version of s3://#{state.bucket}/#{state.key}: #{etag} with version: #{version}"
+      )
+
       {:ok, etag}
     else
       {:error, {:unexpected_response, %{body: reason}}} ->
@@ -87,24 +90,30 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
     end
   end
 
-  defp list_objects(state) do
-    state.bucket
-    |> ExAws.S3.list_objects()
-    |> client().request(region: state.region)
+  defp list_object_versions(state) do
+    res =
+      state.bucket
+      |> ExAws.S3.get_bucket_object_versions(prefix: state.key)
+      |> aws_client_request(state.region)
+
+    with {:ok, %{body: %{versions: versions}}} <- res do
+      {:ok, versions}
+    end
   end
 
   defp get_object(state) do
     state.bucket
     |> ExAws.S3.get_object(state.key)
-    |> client().request(region: state.region)
+    |> aws_client_request(state.region)
   end
 
-  defp find_latest([_ | _] = contents, key) do
+  defp find_latest([_ | _] = contents) do
+    dbg contents
     Enum.find(contents, fn
-      %{key: ^key} ->
+      %{is_latest: "true"} ->
         true
 
-      _ ->
+      %{is_latest: "false"} ->
         false
     end)
     |> case do
@@ -113,7 +122,11 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
     end
   end
 
-  defp find_latest(_, _), do: {:error, :not_found}
+  defp find_latest(_), do: {:error, :not_found}
+
+  defp aws_client_request(op, region) do
+    client().request(op, region: region)
+  end
 
   defp client, do: Application.get_env(:remote_persistent_term, :aws_client, ExAws)
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule RemotePersistentTerm.MixProject do
   use Mix.Project
 
   @name "RemotePersistentTerm"
-  @version "0.10.0"
+  @version "0.11.0"
   @repo_url "https://github.com/AppMonet/remote_persistent_term"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule RemotePersistentTerm.MixProject do
   use Mix.Project
 
   @name "RemotePersistentTerm"
-  @version "0.11.0"
+  @version "0.10.1"
   @repo_url "https://github.com/AppMonet/remote_persistent_term"
 
   def project do


### PR DESCRIPTION
We thought to spread out the changes of my original pr into several. 

This will use the is_latest tag, and also passes in the prefix so that we only lookup the correct object instead of listing all objects in the whole bucket.

I tested and can see the even buckets that are not versioned will return is_latest for an object. e.g for appmonet.com bucket :

```
contents #=> [
  %{
    owner: %{
      id: "a59edb577d3ca9ca18794e866cc0c131d4bb9232f58dc8be4c4d634f9ff784dc",
      display_name: "nick.jacob"
    },
    size: "17100",
    key: "index.html",
    last_modified: "2017-04-01T14:20:53.000Z",
    etag: "\"adf6d5ab13452ec30d7556caaf49fab8\"",
    version_id: "null",
    is_latest: "true"
  }
]
```