### PR TITLE
Add fallback to previous version feature for s3

### DIFF
--- a/lib/remote_persistent_term.ex
+++ b/lib/remote_persistent_term.ex
@@ -281,9 +281,9 @@ defmodule RemotePersistentTerm do
       start_meta,
       fn ->
         {status, version} =
-          with {:ok, current_version} <- state.fetcher_mod.current_version(state.fetcher_state),
+          with {:ok, current_version, updated_fetcher_state} <- state.fetcher_mod.current_version(state.fetcher_state),
                true <- state.current_version != current_version,
-               :ok <- download_and_store_term(state, deserialize_fun, put_fun) do
+               :ok <- download_and_store_term(%{state | fetcher_state: updated_fetcher_state}, deserialize_fun, put_fun) do
             {:updated, current_version}
           else
             false ->

--- a/lib/remote_persistent_term.ex
+++ b/lib/remote_persistent_term.ex
@@ -331,7 +331,10 @@ defmodule RemotePersistentTerm do
         put_fun.(deserialized)
 
       {:error, _reason} = error when state.version_fallback? ->
-        Logger.error("#{state.name} - failed to deserialize remote term, falling back to previous version")
+        Logger.error(
+          "#{state.name} - failed to deserialize remote term, falling back to previous version"
+        )
+
         case state.fetcher_mod.previous_version(state.fetcher_state) do
           {:ok, previous_state} ->
             download_and_store_term(

--- a/lib/remote_persistent_term.ex
+++ b/lib/remote_persistent_term.ex
@@ -76,7 +76,8 @@ defmodule RemotePersistentTerm do
       default: false,
       doc: """
       If true, when deserialization fails, the system will attempt to use previous versions \
-      of the term until a valid version is found or all versions are exhausted.
+      of the term until a valid version is found or all versions are exhausted. \
+      Only currently supported by the S3 fetcher.
       """
     ]
   ]
@@ -330,6 +331,7 @@ defmodule RemotePersistentTerm do
         put_fun.(deserialized)
 
       {:error, _reason} = error when state.version_fallback? ->
+        Logger.error("#{state.name} - failed to deserialize remote term, falling back to previous version")
         case state.fetcher_mod.previous_version(state.fetcher_state) do
           {:ok, previous_state} ->
             download_and_store_term(

--- a/lib/remote_persistent_term/fetcher.ex
+++ b/lib/remote_persistent_term/fetcher.ex
@@ -20,7 +20,7 @@ defmodule RemotePersistentTerm.Fetcher do
   Check the current version of the remote term. Used to avoid downloading the
   same term multiple times.
   """
-  @callback current_version(state()) :: {:ok, version()} | {:error, term()}
+  @callback current_version(state()) :: {:ok, version(), state()} | {:error, term()}
 
   @doc """
   Download the term from the remote source.

--- a/lib/remote_persistent_term/fetcher.ex
+++ b/lib/remote_persistent_term/fetcher.ex
@@ -26,4 +26,10 @@ defmodule RemotePersistentTerm.Fetcher do
   Download the term from the remote source.
   """
   @callback download(state()) :: {:ok, term()} | {:error, term()}
+
+  @doc """
+  Get the previous version of the remote term.
+  Returns a new state that can be used to fetch the previous version.
+  """
+  @callback previous_version(state()) :: {:ok, state()} | {:error, term()}
 end

--- a/lib/remote_persistent_term/fetcher/http.ex
+++ b/lib/remote_persistent_term/fetcher/http.ex
@@ -82,7 +82,7 @@ defmodule RemotePersistentTerm.Fetcher.Http do
   end
 
   @impl true
-  def previous_version(_state), do: {:error, :no_previous_version}
+  def previous_version(_state), do: {:error, :not_supported}
 
   defp response_status(url, status) do
     if status < 300 do

--- a/lib/remote_persistent_term/fetcher/http.ex
+++ b/lib/remote_persistent_term/fetcher/http.ex
@@ -81,6 +81,9 @@ defmodule RemotePersistentTerm.Fetcher.Http do
     end
   end
 
+  @impl true
+  def previous_version(_state), do: {:error, :no_previous_version}
+
   defp response_status(url, status) do
     if status < 300 do
       Logger.info("successfully downloaded remote term from #{url} with status #{status}")

--- a/lib/remote_persistent_term/fetcher/http.ex
+++ b/lib/remote_persistent_term/fetcher/http.ex
@@ -66,8 +66,8 @@ defmodule RemotePersistentTerm.Fetcher.Http do
   end
 
   @impl true
-  def current_version(_state) do
-    {:ok, DateTime.utc_now() |> DateTime.to_string()}
+  def current_version(state) do
+    {:ok, DateTime.utc_now() |> DateTime.to_string(), state}
   end
 
   @impl true

--- a/lib/remote_persistent_term/fetcher/s3.ex
+++ b/lib/remote_persistent_term/fetcher/s3.ex
@@ -148,7 +148,6 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
   end
 
   defp get_object(state) do
-    # aws_client_request(&ExAws.S3.get_object/2, state, state.key)
     aws_client_request(:get_object, state, [state.key, [version_id: state.version_id]])
   end
 

--- a/lib/remote_persistent_term/fetcher/s3.ex
+++ b/lib/remote_persistent_term/fetcher/s3.ex
@@ -210,8 +210,6 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
     end
   end
 
-  defp aws_client_request(op, state, opts \\ [])
-
   defp aws_client_request(op, %{failover_buckets: nil} = state, opts) do
     perform_request(op, state.bucket, state.region, opts)
   end

--- a/lib/remote_persistent_term/fetcher/s3.ex
+++ b/lib/remote_persistent_term/fetcher/s3.ex
@@ -14,9 +14,10 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
           bucket: bucket,
           key: String.t(),
           region: region,
-          failover_buckets: [failover_bucket] | nil
+          failover_buckets: [failover_bucket] | nil,
+          version_id: String.t() | nil
         }
-  defstruct [:bucket, :key, :region, :failover_buckets]
+  defstruct [:bucket, :key, :region, :failover_buckets, :version_id]
 
   @failover_bucket_schema [
     bucket: [
@@ -136,9 +137,9 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
   defp list_object_versions(state) do
     res =
       aws_client_request(
-        &ExAws.S3.get_bucket_object_versions/2,
+        :get_bucket_object_versions,
         state,
-        prefix: state.key
+        [[prefix: state.key]]
       )
 
     with {:ok, %{body: %{versions: versions}}} <- res do
@@ -147,7 +148,8 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
   end
 
   defp get_object(state) do
-    aws_client_request(&ExAws.S3.get_object/2, state, state.key)
+    # aws_client_request(&ExAws.S3.get_object/2, state, state.key)
+    aws_client_request(:get_object, state, [state.key, [version_id: state.version_id]])
   end
 
   defp find_latest([_ | _] = contents) do
@@ -166,6 +168,51 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
 
   defp find_latest(_), do: {:error, :not_found}
 
+  @impl true
+  def previous_version(state) do
+    Logger.info(
+      bucket: state.bucket,
+      key: state.key,
+      message: "About to fetch previous version of object",
+      version_id: state.version_id
+    )
+
+    with {:ok, versions} <- list_object_versions(state),
+         {:ok, previous_version} <- find_previous_version(versions, state.version_id) do
+      {:ok, %{state | version_id: previous_version.version_id}}
+    else
+      {:error, reason} ->
+        Logger.error(%{
+          bucket: state.bucket,
+          key: state.key,
+          reason: inspect(reason),
+          message: "Failed to get previous version of object"
+        })
+
+        {:error, reason}
+    end
+  end
+
+  defp find_previous_version(versions, current_version_id) do
+    versions
+    |> Enum.sort_by(
+      fn version ->
+        {:ok, datetime, _} = DateTime.from_iso8601(version.last_modified)
+        datetime
+      end,
+      {:desc, DateTime}
+    )
+    |> Enum.find(fn version ->
+      version.version_id != current_version_id
+    end)
+    |> case do
+      nil -> {:error, :no_previous_version}
+      version -> {:ok, version}
+    end
+  end
+
+  defp aws_client_request(op, state, opts \\ [])
+
   defp aws_client_request(op, %{failover_buckets: nil} = state, opts) do
     perform_request(op, state.bucket, state.region, opts)
   end
@@ -173,7 +220,7 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
   defp aws_client_request(
          op,
          %{
-           failover_buckets: [_|_] = failover_buckets
+           failover_buckets: [_ | _] = failover_buckets
          } = state,
          opts
        ) do
@@ -222,8 +269,8 @@ defmodule RemotePersistentTerm.Fetcher.S3 do
     end
   end
 
-  defp perform_request(op, bucket, region, opts) do
-    op.(bucket, opts)
+  defp perform_request(func, bucket, region, opts) do
+    apply(ExAws.S3, func, [bucket | opts])
     |> client().request(region: region)
   end
 

--- a/lib/remote_persistent_term/fetcher/static.ex
+++ b/lib/remote_persistent_term/fetcher/static.ex
@@ -28,7 +28,7 @@ defmodule RemotePersistentTerm.Fetcher.Static do
       def download(state), do: {:ok, unquote(Macro.escape(Keyword.fetch!(opts, :data)))}
 
       @impl true
-      def previous_version(_), do: {:error, :no_previous_version}
+      def previous_version(_), do: {:error, :not_supported}
     end
   end
 end

--- a/lib/remote_persistent_term/fetcher/static.ex
+++ b/lib/remote_persistent_term/fetcher/static.ex
@@ -22,10 +22,10 @@ defmodule RemotePersistentTerm.Fetcher.Static do
       def init(_), do: {:ok, []}
 
       @impl true
-      def current_version(_), do: {:ok, unquote(Keyword.get(opts, :version, "1"))}
+      def current_version(state), do: {:ok, unquote(Keyword.get(opts, :version, "1")), state}
 
       @impl true
-      def download(_), do: {:ok, unquote(Macro.escape(Keyword.fetch!(opts, :data)))}
+      def download(state), do: {:ok, unquote(Macro.escape(Keyword.fetch!(opts, :data)))}
 
       @impl true
       def previous_version(_), do: {:error, :no_previous_version}

--- a/lib/remote_persistent_term/fetcher/static.ex
+++ b/lib/remote_persistent_term/fetcher/static.ex
@@ -1,6 +1,6 @@
 defmodule RemotePersistentTerm.Fetcher.Static do
   @moduledoc """
-  A macro to help define a valid `RemotePersistentTerm.Fetcher` which 
+  A macro to help define a valid `RemotePersistentTerm.Fetcher` which
   always returns some hardcoded static data.
 
   Mostly intended for testing purposes.
@@ -26,6 +26,9 @@ defmodule RemotePersistentTerm.Fetcher.Static do
 
       @impl true
       def download(_), do: {:ok, unquote(Macro.escape(Keyword.fetch!(opts, :data)))}
+
+      @impl true
+      def previous_version(_), do: {:error, :no_previous_version}
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule RemotePersistentTerm.MixProject do
   use Mix.Project
 
   @name "RemotePersistentTerm"
-  @version "0.12.0"
+  @version "0.13.0"
   @repo_url "https://github.com/AppMonet/remote_persistent_term"
 
   def project do

--- a/test/remote_persistent_term/fetcher/s3_test.exs
+++ b/test/remote_persistent_term/fetcher/s3_test.exs
@@ -99,7 +99,7 @@ defmodule RemotePersistentTerm.Fetcher.S3Test do
       log =
         capture_log(fn ->
           result = S3.current_version(state)
-          assert {:ok, "current-etag"} = result
+          assert {:ok, "current-etag", _updated_state} = result
         end)
 
       assert log =~ "bucket: \"#{@bucket}\""


### PR DESCRIPTION

    
<!-- This is an auto-generated description by mrge. -->

## Summary by mrge
Added a fallback feature for S3 fetches that tries previous object versions if deserialization fails.

- **New Features**
  - Added `version_fallback?` option to enable automatic fallback to older S3 object versions.
  - Implemented `previous_version/1` for S3 fetcher to retrieve earlier versions.
  - Updated tests to cover fallback logic.

<!-- End of auto-generated description by mrge. -->

